### PR TITLE
Wrap FsCheck runner by only shadowing OnFinished

### DIFF
--- a/Fuchu.FsCheck/FsCheck.fs
+++ b/Fuchu.FsCheck/FsCheck.fs
@@ -16,11 +16,11 @@ module FuchuFsCheck =
         | :? IgnoreException as e -> Some e
         | _ -> None
 
-    let internal runner = 
+    let internal wrapRunner (r : IRunner) =
         { new IRunner with
-            member x.OnStartFixture t = ()
-            member x.OnArguments (ntest,args, every) = ()
-            member x.OnShrink(args, everyShrink) = ()
+            member x.OnStartFixture t = r.OnStartFixture t
+            member x.OnArguments (ntest, args, every) = r.OnArguments (ntest, args, every)
+            member x.OnShrink(args, everyShrink) = r.OnShrink(args, everyShrink)
             member x.OnFinished(name,testResult) = 
                 let msg = onFinishedToString name testResult
                 match testResult with
@@ -31,12 +31,12 @@ module FuchuFsCheck =
 
     let internal config = 
         { Config.Default with
-            Runner = runner }
+            Runner = wrapRunner Config.Default.Runner }
 
     let testPropertyWithConfig (config: Config) name property = 
         let config =
             { config with
-                Runner = runner }
+                Runner = wrapRunner config.Runner }
         testCase name <|
             fun _ ->
                 ignore Runner.init.Value


### PR DESCRIPTION
The current Fuchu runner for FsCheck voids out any actions for `OnStartFixture`, `OnArguments`, and `OnShrink` while also providing the Fuchu implementation for `OnFinished`. For some tests, running `testPropertyWithConfig Config.Verbose …` can be useful for a quick verification that the property has been written correctly. Instead of voiding out the first three methods, this patch passes them through to the underlying runner. This allows the user to use the verbose configuration, or provide another alternate runner.