### PR TITLE
Include FsCheck OnFinished messages

### DIFF
--- a/Fuchu.FsCheck/FsCheck.fs
+++ b/Fuchu.FsCheck/FsCheck.fs
@@ -18,15 +18,14 @@ module FuchuFsCheck =
 
     let internal wrapRunner (r : IRunner) =
         { new IRunner with
-            member x.OnStartFixture t = r.OnStartFixture t
-            member x.OnArguments (ntest, args, every) = r.OnArguments (ntest, args, every)
-            member x.OnShrink(args, everyShrink) = r.OnShrink(args, everyShrink)
-            member x.OnFinished(name,testResult) = 
-                let msg = onFinishedToString name testResult
+            member __.OnStartFixture t = r.OnStartFixture t
+            member __.OnArguments(ntest, args, every) = r.OnArguments(ntest, args, every)
+            member __.OnShrink(args, everyShrink) = r.OnShrink(args, everyShrink)
+            member __.OnFinished(name,testResult) =
                 match testResult with
-                | FsCheck.TestResult.True _ -> ()
+                | FsCheck.TestResult.True _ -> r.OnFinished(name, testResult)
                 | FsCheck.TestResult.False (_,_,_, Outcome.Exception (Ignored e),_) -> raise e
-                | _ -> failtest msg
+                | _ -> failtest (onFinishedToString name testResult)
         }
 
     let internal config = 


### PR DESCRIPTION
This PR includes two FsCheck-related changes, in a similar area to my previous PR.

First, Fuchu is only printing out FsCheck finished messages only in the case of a test that fails. However, when doing property classification, it helps to have that information printed out for successful cases as well. The first commit takes care of allowing the wrapped runner to do its `OnFinished` action in the case that the test passes.

~~Second, FsCheck marks tests as `Exhausted` if the number of _invalid_ test cases generated has reached its configured maximum (`MaxFail`) before the number of _valid_ test cases generated as reached its configured maxiumum (`MaxTest`) _and all valid test cases have passed_. If any of the "valid" test cases has failed, then the test case will be marked as failed. For Fuchu, an `Exhausted` result ought to be accepted as a pass.~~
