### PR TITLE
[WIP] .NET Core with .NET CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ packages/*
 *.nupkg
 .nuget/*.exe
 *.sln.ide
+project.lock.json

--- a/Fuchu/Fuchu.MbUnit.fs
+++ b/Fuchu/Fuchu.MbUnit.fs
@@ -90,7 +90,11 @@ module MbUnit =
 
         let testMethods = Seq.append (getTestMethods testCategory mbUnitAttrs t) rowTests
 
+#if DNXCORE50
+        let test = TestToFuchu mbUnitAttrs (fun t -> t.GetTypeInfo() |> testCategory) t testMethods
+#else
         let test = TestToFuchu mbUnitAttrs testCategory t testMethods
+#endif
 
         let staticTests = 
             nonIgnoredMethods [MbUnitAttr "StaticTestFactory"]
@@ -101,5 +105,9 @@ module MbUnit =
         TestList (seq {
             yield test
             if staticTests.Length > 0 then
+#if DNXCORE50
+                yield testList (t.FullName + testCategory (t.GetTypeInfo())) staticTests
+#else
                 yield testList (t.FullName + testCategory t) staticTests
+#endif
         })

--- a/Fuchu/Fuchu.MbUnit.fs
+++ b/Fuchu/Fuchu.MbUnit.fs
@@ -59,6 +59,9 @@ module MbUnit =
 
         let testCategory (m: MemberInfo) =
             m.GetCustomAttributes(categoryAttributeType.Value, true)
+#if DNXCORE50
+            |> Array.ofSeq
+#endif
             |> Array.map (fun a -> categoryAttributeNameProperty.Value.GetValue(a, null) :?> string)
             |> Enumerable.FirstOrDefault
 

--- a/Fuchu/NuGet.Config
+++ b/Fuchu/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Fuchu/project.json
+++ b/Fuchu/project.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+    },
+
+    "compilerName": "fsc",
+    "compileFiles": [
+        "AssemblyInfo.fs",
+        "Fuchu.fs",
+        "Assertions.fs",
+        "xUnitHelpers.fs",
+        "Fuchu.NUnit.fs",
+        "Fuchu.MbUnit.fs"
+    ],
+
+    "frameworks": {
+        "net46": { 
+             "dependencies": {
+                 "FSharp.Core": "4.0.0.1"
+             }
+        },
+
+        "dnxcore50": {
+             "dependencies": {
+                 "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+                 "NETStandard.Library": "1.0.0-rc2-23811"
+             }
+         }
+    }
+}

--- a/Fuchu/project.json
+++ b/Fuchu/project.json
@@ -23,6 +23,7 @@
         "dnxcore50": {
              "dependencies": {
                  "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+                 "System.Diagnostics.TraceSource": "4.0.0-rc2-23811",
                  "NETStandard.Library": "1.0.0-rc2-23811"
              }
          }

--- a/Fuchu/project.json
+++ b/Fuchu/project.json
@@ -24,6 +24,7 @@
              "dependencies": {
                  "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
                  "System.Diagnostics.TraceSource": "4.0.0-rc2-23811",
+                 "System.Linq.Parallel": "4.0.1-rc2-23811",
                  "NETStandard.Library": "1.0.0-rc2-23811"
              }
          }

--- a/Fuchu/xUnitHelpers.fs
+++ b/Fuchu/xUnitHelpers.fs
@@ -17,7 +17,11 @@ module XunitHelpers =
 
     let nonIgnoredMethods ignoreAttr (t: Type) =
         [t]
+#if DNXCORE50
+        |> Seq.filter (fun t -> not (t.GetTypeInfo().HasAttribute ignoreAttr))
+#else
         |> Seq.filter (fun t -> not (t.HasAttribute ignoreAttr))
+#endif
         |> Seq.collect (fun _ -> t.GetMethods())
 
     let propertyValue propertyName o =
@@ -59,7 +63,11 @@ module XunitHelpers =
                                Invoke = fun (o: obj) -> invoke o m })
 
     let TestToFuchu (attr: TestAttributes) (testCategory: Type -> string) (testType: Type) (testMethods: TestMethod seq) =
+#if DNXCORE50
+        if testType.GetTypeInfo().IsAbstract
+#else
         if testType.IsAbstract
+#endif
             then TestList []
             else
                 let methods = nonIgnoredMethods attr.Ignore testType


### PR DESCRIPTION
ref #50 
- [X] Fuchu library
- [ ] Smoke tests using .net cli
- [ ] Fuchu.Tests (nunit/xunit)

``` bash
dotnet restore
cd Fuchu
dotnet --verbose build --framework dnxcore50 --configuration Release
```

the .net core need f# 4

About testing, i think i can do nunit and xnunit in `Fuchu.Tests` the others (MbUnit, PerfTest, FsCheck) i think are not supported atm, no .net core packages
