### PR TITLE
V1 run compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <VersionPrefix>1.2.0</VersionPrefix>
-        <VersionSuffix>beta-1</VersionSuffix>
+        <VersionSuffix>beta-2</VersionSuffix>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
         <Version Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</Version>

--- a/Fuchu/Fuchu.fs
+++ b/Fuchu/Fuchu.fs
@@ -298,6 +298,7 @@ module Impl =
         Exception: string -> exn -> unit
         #endif
     } with
+        /// The Default test printers is to not print out anything at all
         static member Default = {
             BeforeRun = ignore
             Ignored = ignore2
@@ -449,6 +450,7 @@ module Impl =
                                      Failed = printFailed
                                      Exception = printException }
 #if !FABLE_COMPILER
+    /// Parallel map of a sequence
     let pmap (f: _ -> _) (s: _ seq) = s.AsParallel().Select(f) :> _ seq
     /// Evaluates tests in parallel
     let evalPar printer =


### PR DESCRIPTION
In earlier pull request I accidentally introduced a breaking change to the v1 API. In order to avoid that I've renamed the new function to runPrint and reintroduced the run function.